### PR TITLE
WiFi Scan nicht nur auf dem ersten Interface

### DIFF
--- a/files/www/lan/style.css
+++ b/files/www/lan/style.css
@@ -86,7 +86,8 @@ fieldset {
 	border: 1px solid #ddd;
 	padding: 0.5em;
 	margin: 0.5em;
-	width: 38em;
+	width: 90%;
+	max-width: 38em;
 }
 
 fieldset fieldset {
@@ -244,6 +245,16 @@ button {
 	#globalnav.responsive li a {
 		display: block;
 		text-align: left;
+	}
+}
+
+@media screen and (max-width: 600px) {
+	fieldset div > label {
+		width: auto;
+		font-style: italic;
+	}
+	fieldset div > span {
+		float: right;
 	}
 }
 

--- a/files/www/lan/wifiscan.js
+++ b/files/www/lan/wifiscan.js
@@ -73,7 +73,6 @@ function add_list_entry(device, ifname) {
 
 /*
 * Create a selection of wireless devices
-* represented as the first interface found.
 */
 function init() {
 	send("/cgi-bin/misc", {func:'wifi_status'}, function(data) {
@@ -83,9 +82,11 @@ function init() {
 			if (interfaces.length == 0) {
 				continue;
 			}
-			var ifname = interfaces[0].ifname ;
-			if (typeof(ifname) == 'string') {
-				add_list_entry(device, ifname);
+			for (var interface in interfaces) {
+				var ifname = interfaces[interface].ifname;
+				if (typeof(ifname) == 'string') {
+					add_list_entry(device, ifname);
+				}
 			}
 		}
 	});


### PR DESCRIPTION
Bei mir läuft auf dem ersten IF das Mesh und auf dem zweiten IF erst ein WiFi mit ifname.
Folglich bringt es mir nichts das Dropdown nur mit dem ifname des ersten Devices falls vorhanden zu bestücken.
Ich hab da mal 'ne for-each für alle Interfaces draus gemacht (Check ob Name da ist bleibt natürlich)

